### PR TITLE
Bump heading sizes down a level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,28 @@
 
 ## Released
 
+### [0.2.1] - 2023-08-21
+
+- Bump heading sizes down a level [#12](https://github.com/alphagov/govuk-forms-markdown/pull/12/)
+
 ### [0.2.0] - 2023-08-015
+
 - All links should open in a new tab [#9](https://github.com/alphagov/govuk-forms-markdown/issues/9)
 
 ### [0.1.0] - 2023-08-03
 
 - Initial release
 - Adds custom render methods for markdown syntax we would like to support.
-  
+
   - Heading levels 2 & 3, anything else returns as unstyled text
-  - Links styled like GOV.UK 
+  - Links styled like GOV.UK
   - Lists (ordered and unordered)
+
 - We do not support the following
-  
+
   - Heading level 1
   - tables
   - horizontal rules
   - emphasis
   - code blocks
   - custom HTML
-  

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-forms-markdown (0.2.0)
+    govuk-forms-markdown (0.2.1)
       redcarpet (~> 3.6)
 
 GEM

--- a/lib/govuk-forms-markdown/renderer.rb
+++ b/lib/govuk-forms-markdown/renderer.rb
@@ -11,8 +11,8 @@ module GovukFormsMarkdown
 
     def header(text, header_level)
       heading_size = case header_level
-                     when 2 then "l"
-                     when 3 then "m"
+                     when 2 then "m"
+                     when 3 then "s"
                      end
 
       if heading_size.nil?

--- a/lib/govuk-forms-markdown/version.rb
+++ b/lib/govuk-forms-markdown/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukFormsMarkdown
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/govuk-forms-markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk-forms-markdown/govuk_forms_markdown_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe GovukFormsMarkdown do
   end
 
   it "renders H2s and GOV.UK classes" do
-    expect(render("## Top heading")).to eq('<h2 class="govuk-heading-l">Top heading</h2>')
+    expect(render("## Top heading")).to eq('<h2 class="govuk-heading-m">Top heading</h2>')
   end
 
   it "renders H3s with ids and GOV.UK classes" do
-    expect(render("### A heading")).to eq('<h3 class="govuk-heading-m">A heading</h3>')
+    expect(render("### A heading")).to eq('<h3 class="govuk-heading-s">A heading</h3>')
   end
 
   it "renders paragraphs with GOV.UK classes" do
@@ -91,7 +91,7 @@ RSpec.describe GovukFormsMarkdown do
 
   context "when unsafe content is used it should be escaped" do
     it "renders escaped H2s and GOV.UK classes" do
-      expect(render("## <script>alert('Hacked');</script>")).to eq('<h2 class="govuk-heading-l">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</h2>')
+      expect(render("## <script>alert('Hacked');</script>")).to eq('<h2 class="govuk-heading-m">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</h2>')
     end
 
     it "renders escaped p and GOV.UK classes" do

--- a/spec/govuk-forms-markdown/renderer/header_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/header_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#header" do
     supported_heading_levels = [2, 3]
     supported_heading_levels.each do |level|
       it "does format heading level #{level}" do
-        heading_size = level == 2 ? "l" : "m"
+        heading_size = level == 2 ? "m" : "s"
         expect(renderer.header("Heading level #{level}", level).strip).to eq "<h#{level} class=\"govuk-heading-#{heading_size}\">Heading level #{level}</h#{level}>"
       end
     end


### PR DESCRIPTION
Bumps heading sizes down a level to keep our visual heirarchy consistent in light of the fact that we use size `l` h1 elements on most Forms pages in the runner.