### PR TITLE
Add validations for length and unsupported markdown syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### [0.3.0] - xxxx-xx-xx
+
+- Add a Validator check if markdown is not too long or using unsupported markdown syntax [#13](https://github.com/alphagov/govuk-forms-markdown/pull/13) 
+
 ## Released
 
 ### [0.2.1] - 2023-08-21

--- a/lib/govuk-forms-markdown/renderer.rb
+++ b/lib/govuk-forms-markdown/renderer.rb
@@ -42,14 +42,17 @@ module GovukFormsMarkdown
     end
 
     def emphasis(text)
+      add_to_error(:used_emphasis)
       text
     end
 
     def double_emphasis(text)
+      add_to_error(:used_emphasis)
       text
     end
 
     def triple_emphasis(text)
+      add_to_error(:used_emphasis)
       text
     end
 

--- a/lib/govuk-forms-markdown/renderer.rb
+++ b/lib/govuk-forms-markdown/renderer.rb
@@ -38,6 +38,7 @@ module GovukFormsMarkdown
     end
 
     def hrule
+      add_to_error(:used_hrule)
       nil
     end
 

--- a/lib/govuk-forms-markdown/renderer.rb
+++ b/lib/govuk-forms-markdown/renderer.rb
@@ -34,6 +34,7 @@ module GovukFormsMarkdown
     end
 
     def block_quote(quote)
+      add_to_error(:used_block_quote)
       paragraph(quote)
     end
 

--- a/lib/govuk-forms-markdown/renderer.rb
+++ b/lib/govuk-forms-markdown/renderer.rb
@@ -3,10 +3,12 @@
 module GovukFormsMarkdown
   class Renderer < ::Redcarpet::Render::Safe
     class Error < StandardError; end
-    # Your code goes here...
+
+    attr_reader :errors
 
     def initialize(options = {})
       super options
+      @errors = []
     end
 
     def header(text, header_level)
@@ -16,6 +18,7 @@ module GovukFormsMarkdown
                      end
 
       if heading_size.nil?
+        add_to_error(:heading_levels)
         paragraph(text)
       else
         <<~HTML
@@ -71,6 +74,13 @@ module GovukFormsMarkdown
       else
         raise GovukFormsMarkdown::Error, "Unexpected type #{list_type.inspect}"
       end
+    end
+
+  private
+
+    def add_to_error(error)
+      symbolized_error = error.to_sym
+      errors << symbolized_error unless errors.include?(symbolized_error)
     end
   end
 end

--- a/lib/govuk-forms-markdown/validator.rb
+++ b/lib/govuk-forms-markdown/validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "redcarpet"
+require "redcarpet/render_strip"
+
+module GovukFormsMarkdown
+  class Validator
+    attr_accessor :markdown, :errors
+
+    def initialize(markdown = "")
+      @markdown = markdown
+    end
+
+    def validate_length
+      markdown_without_syntax = Redcarpet::Markdown.new(Redcarpet::Render::StripDown).render(markdown).strip
+
+      :too_long if markdown_without_syntax.length >= 5000
+    end
+  end
+end

--- a/lib/govuk-forms-markdown/validator.rb
+++ b/lib/govuk-forms-markdown/validator.rb
@@ -13,6 +13,10 @@ module GovukFormsMarkdown
       @markdown = markdown
     end
 
+    def validate
+      { errors: [validate_length, validate_tags].compact.flatten }
+    end
+
     def validate_length
       markdown_without_syntax = Redcarpet::Markdown.new(Redcarpet::Render::StripDown).render(markdown).strip
 

--- a/lib/govuk-forms-markdown/validator.rb
+++ b/lib/govuk-forms-markdown/validator.rb
@@ -3,6 +3,8 @@
 require "redcarpet"
 require "redcarpet/render_strip"
 
+require_relative "./renderer"
+
 module GovukFormsMarkdown
   class Validator
     attr_accessor :markdown, :errors
@@ -15,6 +17,14 @@ module GovukFormsMarkdown
       markdown_without_syntax = Redcarpet::Markdown.new(Redcarpet::Render::StripDown).render(markdown).strip
 
       :too_long if markdown_without_syntax.length >= 5000
+    end
+
+    def validate_tags
+      return nil if markdown.nil? || markdown.empty?
+
+      renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } })
+      Redcarpet::Markdown.new(renderer, no_intra_emphasis: true).render(markdown)
+      renderer.errors if renderer.errors.any?
     end
   end
 end

--- a/lib/govuk_forms_markdown.rb
+++ b/lib/govuk_forms_markdown.rb
@@ -2,6 +2,7 @@ require "redcarpet"
 
 require_relative "./govuk-forms-markdown/version"
 require_relative "./govuk-forms-markdown/renderer"
+require_relative "./govuk-forms-markdown/validator"
 
 module GovukFormsMarkdown
   class Error < StandardError; end
@@ -9,5 +10,9 @@ module GovukFormsMarkdown
   def self.render(markdown)
     renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } })
     Redcarpet::Markdown.new(renderer, no_intra_emphasis: true).render(markdown).strip
+  end
+
+  def self.validate(markdown)
+    GovukFormsMarkdown::Validator.new(markdown).validate
   end
 end

--- a/spec/govuk-forms-markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk-forms-markdown/govuk_forms_markdown_spec.rb
@@ -5,131 +5,157 @@ RSpec.describe GovukFormsMarkdown do
     expect(GovukFormsMarkdown::VERSION).not_to be nil
   end
 
-  it "does not render tables" do
-    markdown =
-      <<~MD
-        | First name   | Last name    | DOB        |
-        | ------------ | ------------ | ---------- |
-        | John         | Smith        | 01-04-1970 |
-        | Alison       | Brown        | 02-05-1970 |
-        | Adam         | Sample       | 03-06-1970 |
-      MD
+  describe ".render" do
+    it "does not render tables" do
+      markdown =
+        <<~MD
+          | First name   | Last name    | DOB        |
+          | ------------ | ------------ | ---------- |
+          | John         | Smith        | 01-04-1970 |
+          | Alison       | Brown        | 02-05-1970 |
+          | Adam         | Sample       | 03-06-1970 |
+        MD
 
-    expected_html = <<~HTML
-      <p class="govuk-body">
-        | First name   | Last name    | DOB        |
-        | ------------ | ------------ | ---------- |
-        | John         | Smith        | 01-04-1970 |
-        | Alison       | Brown        | 02-05-1970 |
-        | Adam         | Sample       | 03-06-1970 |
-      </p>
-    HTML
+      expected_html = <<~HTML
+        <p class="govuk-body">
+          | First name   | Last name    | DOB        |
+          | ------------ | ------------ | ---------- |
+          | John         | Smith        | 01-04-1970 |
+          | Alison       | Brown        | 02-05-1970 |
+          | Adam         | Sample       | 03-06-1970 |
+        </p>
+      HTML
 
-    expect_equal_ignoring_ws(render(markdown), expected_html)
-  end
+      expect_equal_ignoring_ws(render(markdown), expected_html)
+    end
 
-  it "renders H2s and GOV.UK classes" do
-    expect(render("## Top heading")).to eq('<h2 class="govuk-heading-m">Top heading</h2>')
-  end
+    it "renders H2s and GOV.UK classes" do
+      expect(render("## Top heading")).to eq('<h2 class="govuk-heading-m">Top heading</h2>')
+    end
 
-  it "renders H3s with ids and GOV.UK classes" do
-    expect(render("### A heading")).to eq('<h3 class="govuk-heading-s">A heading</h3>')
-  end
+    it "renders H3s with ids and GOV.UK classes" do
+      expect(render("### A heading")).to eq('<h3 class="govuk-heading-s">A heading</h3>')
+    end
 
-  it "renders paragraphs with GOV.UK classes" do
-    expect(render("abc")).to eq('<p class="govuk-body">abc</p>')
-  end
+    it "renders paragraphs with GOV.UK classes" do
+      expect(render("abc")).to eq('<p class="govuk-body">abc</p>')
+    end
 
-  it "renders code without emphasis" do
-    expect(render("I am a snake_cased_word")).to include("snake_cased_word")
-  end
+    it "renders code without emphasis" do
+      expect(render("I am a snake_cased_word")).to include("snake_cased_word")
+    end
 
-  it "renders unordered lists with GOV.UK classes" do
-    input = <<~MARKDOWN
-      * abc def
-      * xyz
-    MARKDOWN
-    expected = <<~HTML
-      <ul class="govuk-list govuk-list--bullet">
-        <li>abc def</li>
-      <li>xyz</li>
-
-      </ul>
-    HTML
-    expect(render(input)).to eq(expected.strip)
-  end
-
-  it "renders ordered lists with GOV.UK classes" do
-    input = <<~MARKDOWN
-      1. abc def
-      2. xyz
-    MARKDOWN
-    expected_html = <<~HTML
-      <ol class="govuk-list govuk-list--number">
-        <li>abc def</li>
+    it "renders unordered lists with GOV.UK classes" do
+      input = <<~MARKDOWN
+        * abc def
+        * xyz
+      MARKDOWN
+      expected = <<~HTML
+        <ul class="govuk-list govuk-list--bullet">
+          <li>abc def</li>
         <li>xyz</li>
-      </ol>
-    HTML
-    expect_equal_ignoring_ws(render(input), expected_html)
-  end
 
-  it "renders a URL in angle brackets with GOV.UK classes" do
-    expect(render("<https://www.gov.uk/help>")).to eq(
-      '<p class="govuk-body"><a href="https://www.gov.uk/help" class="govuk-link" rel="noreferrer noopener" target="_blank">https://www.gov.uk/help</a></p>',
-    )
-  end
-
-  it "renders an email address in angle brackets with GOV.UK classes" do
-    expect(render("<noreply@gov.uk>")).to eq(
-      '<p class="govuk-body"><a href="mailto:noreply@gov.uk" class="govuk-link" rel="noreferrer noopener" target="_blank">noreply@gov.uk</a></p>',
-    )
-  end
-
-  it "does not render hrules with GOV.UK classes" do
-    expect(render("---")).to eq ""
-  end
-
-  context "when unsafe content is used it should be escaped" do
-    it "renders escaped H2s and GOV.UK classes" do
-      expect(render("## <script>alert('Hacked');</script>")).to eq('<h2 class="govuk-heading-m">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</h2>')
-    end
-
-    it "renders escaped p and GOV.UK classes" do
-      input = <<~MARKDOWN
-        <script>alert('Hacked');</script>
-
-        <script>alert('Hacked');</script>
-
-        <script>alert('Hacked');</script>
-      MARKDOWN
-
-      expected_html = <<~HTML
-        <p class="govuk-body">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</p>
-        <p class="govuk-body">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</p>
-        <p class="govuk-body">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</p>
-      HTML
-
-      expect_equal_ignoring_ws(render(input), expected_html)
-    end
-
-    it "escapes html tags" do
-      input = <<~MARKDOWN
-        <div>My new section</div>
-
-        <p>Let me add my own paragraph tags</p>
-
-        <ul>
-          <li>List with one item</li>
         </ul>
-      MARKDOWN
-
-      expected_html = <<~HTML
-        <p class="govuk-body">&lt;div&gt;My new section&lt;/div&gt;</p>
-        <p class="govuk-body">&lt;p&gt;Let me add my own paragraph tags&lt;/p&gt;</p>
-        <p class="govuk-body">&lt;ul&gt;\n  &lt;li&gt;List with one item&lt;/li&gt;\n&lt;/ul&gt;</p>
       HTML
+      expect(render(input)).to eq(expected.strip)
+    end
 
+    it "renders ordered lists with GOV.UK classes" do
+      input = <<~MARKDOWN
+        1. abc def
+        2. xyz
+      MARKDOWN
+      expected_html = <<~HTML
+        <ol class="govuk-list govuk-list--number">
+          <li>abc def</li>
+          <li>xyz</li>
+        </ol>
+      HTML
       expect_equal_ignoring_ws(render(input), expected_html)
+    end
+
+    it "renders a URL in angle brackets with GOV.UK classes" do
+      expect(render("<https://www.gov.uk/help>")).to eq(
+        '<p class="govuk-body"><a href="https://www.gov.uk/help" class="govuk-link" rel="noreferrer noopener" target="_blank">https://www.gov.uk/help</a></p>',
+      )
+    end
+
+    it "renders an email address in angle brackets with GOV.UK classes" do
+      expect(render("<noreply@gov.uk>")).to eq(
+        '<p class="govuk-body"><a href="mailto:noreply@gov.uk" class="govuk-link" rel="noreferrer noopener" target="_blank">noreply@gov.uk</a></p>',
+      )
+    end
+
+    it "does not render hrules with GOV.UK classes" do
+      expect(render("---")).to eq ""
+    end
+
+    context "when unsafe content is used it should be escaped" do
+      it "renders escaped H2s and GOV.UK classes" do
+        expect(render("## <script>alert('Hacked');</script>")).to eq('<h2 class="govuk-heading-m">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</h2>')
+      end
+
+      it "renders escaped p and GOV.UK classes" do
+        input = <<~MARKDOWN
+          <script>alert('Hacked');</script>
+
+          <script>alert('Hacked');</script>
+
+          <script>alert('Hacked');</script>
+        MARKDOWN
+
+        expected_html = <<~HTML
+          <p class="govuk-body">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</p>
+          <p class="govuk-body">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</p>
+          <p class="govuk-body">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</p>
+        HTML
+
+        expect_equal_ignoring_ws(render(input), expected_html)
+      end
+
+      it "escapes html tags" do
+        input = <<~MARKDOWN
+          <div>My new section</div>
+
+          <p>Let me add my own paragraph tags</p>
+
+          <ul>
+            <li>List with one item</li>
+          </ul>
+        MARKDOWN
+
+        expected_html = <<~HTML
+          <p class="govuk-body">&lt;div&gt;My new section&lt;/div&gt;</p>
+          <p class="govuk-body">&lt;p&gt;Let me add my own paragraph tags&lt;/p&gt;</p>
+          <p class="govuk-body">&lt;ul&gt;\n  &lt;li&gt;List with one item&lt;/li&gt;\n&lt;/ul&gt;</p>
+        HTML
+
+        expect_equal_ignoring_ws(render(input), expected_html)
+      end
+    end
+  end
+
+  describe ".validate" do
+    it "returns JSON with error key being an empty array" do
+      expect(validate("## Heading level 2")[:errors]).to be_empty
+    end
+
+    context "when markdown is too long" do
+      it "returns JSON with error key containing too_long" do
+        expect(validate("A" * 5000)[:errors]).to eq [:too_long]
+      end
+    end
+
+    context "when markdown is using unsupported syntax" do
+      it "returns JSON with error key containing heading_levels" do
+        expect(validate("# Heading level 1")[:errors]).to eq [:heading_levels]
+      end
+    end
+
+    context "when markdown is to long and using unsupported syntax" do
+      it "returns JSON with error key containing multiple symbols" do
+        expect(validate("# Heading level 1" * 5000)[:errors]).to eq %i[too_long heading_levels]
+      end
     end
   end
 end

--- a/spec/govuk-forms-markdown/renderer/block_quote_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/block_quote_spec.rb
@@ -7,5 +7,22 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#block_quote" do
   it "does not format blockquote" do
     expect(renderer.block_quote("This is a quote").strip).to eq "<p class=\"govuk-body\">This is a quote</p>"
   end
+
+  describe "rendering errors" do
+    it "does log an error for block quote being used" do
+      renderer.block_quote("This is a quote")
+      expect(renderer.errors).to eq([:used_block_quote])
+    end
+
+    context "when block quote is called multiple times in a single render" do
+      it "returns only 1 single warning for that one render" do
+        renderer.block_quote("This is a quote")
+        renderer.block_quote("This is a quote")
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:used_block_quote])
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/govuk-forms-markdown/renderer/double_emphasis_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/double_emphasis_spec.rb
@@ -7,5 +7,22 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#double_emphasis" do
   it "does not format double_emphasis" do
     expect(renderer.double_emphasis("very important text")).to eq "very important text"
   end
+
+  describe "rendering errors" do
+    it "does log an error for double emphasis being used" do
+      renderer.double_emphasis("very important text")
+      expect(renderer.errors).to eq([:used_emphasis])
+    end
+
+    context "when double_emphasis is called multiple times in a single render" do
+      it "returns only 1 single warning for that one render" do
+        renderer.double_emphasis("important text")
+        renderer.double_emphasis("very important text")
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:used_emphasis])
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/govuk-forms-markdown/renderer/emphasis_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/emphasis_spec.rb
@@ -7,5 +7,33 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#emphasis" do
   it "does not format emphasis" do
     expect(renderer.emphasis("important text")).to eq "important text"
   end
+
+  describe "rendering errors" do
+    it "does log an error for emphasis being used" do
+      renderer.emphasis("important text")
+      expect(renderer.errors).to eq([:used_emphasis])
+    end
+
+    context "when emphasis is called multiple times in a single render" do
+      it "returns only 1 single warning for that one render" do
+        renderer.emphasis("important text")
+        renderer.emphasis("very important text")
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:used_emphasis])
+      end
+    end
+
+    context "when emphasis, double_emphasis and triple is called in the single render" do
+      it "returns only 1 single warning for that one render" do
+        renderer.emphasis("important text")
+        renderer.double_emphasis("very important text")
+        renderer.triple_emphasis("extremely important text")
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:used_emphasis])
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/govuk-forms-markdown/renderer/header_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/header_spec.rb
@@ -4,8 +4,10 @@
 RSpec.describe GovukFormsMarkdown::Renderer, "#header" do
   subject(:renderer) { described_class.new }
 
+  non_supported_heading_levels = [1, 4, 5, 6]
+  supported_heading_levels = [2, 3]
+
   context "when using non-supported heading levels" do
-    non_supported_heading_levels = [1, 4, 5, 6]
     non_supported_heading_levels.each do |level|
       it "does not format heading level #{level}" do
         expect(renderer.header("Heading level #{level}", level).strip).to eq "<p class=\"govuk-body\">Heading level #{level}</p>"
@@ -14,11 +16,37 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#header" do
   end
 
   context "when using supported heading levels" do
-    supported_heading_levels = [2, 3]
     supported_heading_levels.each do |level|
       it "does format heading level #{level}" do
         heading_size = level == 2 ? "m" : "s"
         expect(renderer.header("Heading level #{level}", level).strip).to eq "<h#{level} class=\"govuk-heading-#{heading_size}\">Heading level #{level}</h#{level}>"
+      end
+    end
+  end
+
+  describe "rendering errors" do
+    supported_heading_levels.each do |level|
+      it "does not log a warning for heading level #{level}" do
+        renderer.header("Heading level #{level}", level)
+        expect(renderer.errors).to be_empty
+      end
+    end
+
+    non_supported_heading_levels.each do |level|
+      it "does log a warning for heading level #{level}" do
+        renderer.header("Heading level #{level}", level)
+        expect(renderer.errors).to eq([:heading_levels])
+      end
+    end
+
+    context "when header is called multiple times in a single render" do
+      it "returns only 1 single warning for that one render" do
+        non_supported_heading_levels.each do |level|
+          renderer.header("Heading level #{level}", level)
+        end
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:heading_levels])
       end
     end
   end

--- a/spec/govuk-forms-markdown/renderer/hrule_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/hrule_spec.rb
@@ -7,5 +7,22 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#hrule" do
   it "does not render hrule" do
     expect(renderer.hrule).to eq nil
   end
+
+  describe "rendering errors" do
+    it "does log an error for horizontal being used" do
+      renderer.hrule
+      expect(renderer.errors).to eq([:used_hrule])
+    end
+
+    context "when hrule is called multiple times in a single render" do
+      it "returns only 1 single warning for that one render" do
+        renderer.hrule
+        renderer.hrule
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:used_hrule])
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/govuk-forms-markdown/renderer/triple_emphasis_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/triple_emphasis_spec.rb
@@ -7,5 +7,22 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#triple_emphasis" do
   it "does not format triple_emphasis" do
     expect(renderer.triple_emphasis("extremely important text")).to eq "extremely important text"
   end
+
+  describe "rendering errors" do
+    it "does log an error for tripe emphasis being used" do
+      renderer.triple_emphasis("extremely important text")
+      expect(renderer.errors).to eq([:used_emphasis])
+    end
+
+    context "when triple_emphasis is called multiple times in a single render" do
+      it "returns only 1 single warning for that one render" do
+        renderer.triple_emphasis("important text")
+        renderer.triple_emphasis("very important text")
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:used_emphasis])
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/govuk-forms-markdown/validator/validator_spec.rb
+++ b/spec/govuk-forms-markdown/validator/validator_spec.rb
@@ -2,7 +2,7 @@
 
 # rubocop:disable RSpec/FilePath
 RSpec.describe GovukFormsMarkdown::Validator do
-  subject(:validator) { described_class.new(markdown) }
+  let(:validator) { described_class.new(markdown) }
 
   describe "#validate_length" do
     context "when markdown is empty string" do
@@ -82,6 +82,32 @@ RSpec.describe GovukFormsMarkdown::Validator do
 
       it "returns all errors" do
         expect(validator.validate_tags).to eq([:unsupported_tags_used])
+      end
+    end
+  end
+
+  describe "#validate" do
+    let(:markdown) { "# Some markdown text" }
+
+    context "when validate methods return nil" do
+      before do
+        allow(validator).to receive(:validate_length).and_return(nil)
+        allow(validator).to receive(:validate_tags).and_return(nil)
+      end
+
+      it "removes any nil in the error array" do
+        expect(validator.validate).to eq({ errors: [] })
+      end
+    end
+
+    context "when validate methods return arrays" do
+      before do
+        allow(validator).to receive(:validate_length).and_return(%i[one two])
+        allow(validator).to receive(:validate_tags).and_return(%i[three four])
+      end
+
+      it "flattens array values" do
+        expect(validator.validate).to eq({ errors: %i[one two three four] })
       end
     end
   end

--- a/spec/govuk-forms-markdown/validator/validator_spec.rb
+++ b/spec/govuk-forms-markdown/validator/validator_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe GovukFormsMarkdown::Validator do
+  subject(:validator) { described_class.new(markdown) }
+
+  describe "#validate_length" do
+
+    context "when markdown is empty string" do
+      let(:markdown) { "" }
+
+      it "returns nil" do
+        expect(validator.validate_length).to be_nil
+      end
+    end
+
+    context "when markdown more than 5k characters but once syntax stripped is 4960 characters" do
+      let(:markdown_with_5890_chars) { "# Heading level 1 \n" * 310 }
+      let(:markdown) { markdown_with_5890_chars }
+
+      it "returns nil" do
+        expect(validator.validate_length).to be_nil
+      end
+    end
+
+    context "when markdown eq 5k characters" do
+      let(:markdown) { "a" * 5000 }
+
+      it "returns :too_long symbol" do
+        expect(validator.validate_length).to eq(:too_long)
+      end
+    end
+
+    context "when markdown more than 5k characters but once syntax stripped is 5120 characters" do
+      let(:markdown_with_6080_chars) { "# Heading level 1 \n" * 320 }
+      let(:markdown) { markdown_with_6080_chars }
+
+      it "returns :too_long symbol" do
+        expect(validator.validate_length).to eq(:too_long)
+      end
+    end
+
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/govuk-forms-markdown/validator/validator_spec.rb
+++ b/spec/govuk-forms-markdown/validator/validator_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe GovukFormsMarkdown::Validator do
   subject(:validator) { described_class.new(markdown) }
 
   describe "#validate_length" do
-
     context "when markdown is empty string" do
       let(:markdown) { "" }
 
@@ -39,7 +38,52 @@ RSpec.describe GovukFormsMarkdown::Validator do
         expect(validator.validate_length).to eq(:too_long)
       end
     end
+  end
 
+  describe "#validate_tags" do
+    context "when markdown is empty string" do
+      let(:markdown) { "" }
+
+      it "returns nil" do
+        expect(validator.validate_tags).to be_nil
+      end
+    end
+
+    context "when markdown is using supported tags" do
+      let(:markdown) { "## Supported heading levels" }
+
+      before do
+        # Stub out the GovukFormsMarkdown::Renderer.new and its methods
+        renderer_double = instance_double(GovukFormsMarkdown::Renderer, errors: [])
+        allow(GovukFormsMarkdown::Renderer).to receive(:new).and_return(renderer_double)
+
+        # Stub out Redcarpet::Markdown.new to return a double
+        markdown_double = instance_double(Redcarpet::Markdown, render: nil)
+        allow(Redcarpet::Markdown).to receive(:new).and_return(markdown_double)
+      end
+
+      it "returns nil" do
+        expect(validator.validate_tags).to be_nil
+      end
+    end
+
+    context "when markdown is using unsupported tags" do
+      let(:markdown) { "# Invalid [markdown]" }
+
+      before do
+        # Stub out the GovukFormsMarkdown::Renderer.new and its methods
+        renderer_double = instance_double(GovukFormsMarkdown::Renderer, errors: [:unsupported_tags_used])
+        allow(GovukFormsMarkdown::Renderer).to receive(:new).and_return(renderer_double)
+
+        # Stub out Redcarpet::Markdown.new to return a double
+        markdown_double = instance_double(Redcarpet::Markdown, render: nil)
+        allow(Redcarpet::Markdown).to receive(:new).and_return(markdown_double)
+      end
+
+      it "returns all errors" do
+        expect(validator.validate_tags).to eq([:unsupported_tags_used])
+      end
+    end
   end
 end
 # rubocop:enable RSpec/FilePath

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@ def render(content)
   GovukFormsMarkdown.render(content)
 end
 
+def validate(content)
+  GovukFormsMarkdown.validate(content)
+end
+
 def expect_equal_ignoring_ws(first, second)
   expect(first.lines.map(&:strip).join("")).to eq(second.lines.map(&:strip).join(""))
 end


### PR DESCRIPTION
## Changes

This PR adds a new Validator  class to the gem which will validate two things 

- markdown length is under 5k characters (after removing markdown syntax)
- markdown does not include any unsupported markdown syntax (eg. not H2/H3, horizontal rule, bold, etc)


To validate the markdown all that is needed is to call the following after requiring the class

```
require "govuk_forms_markdown"

# content is a string of markdown
errors = GovukFormsMarkdown.validate(content)

```

It should return  a hash as follows

```
# no errors
{ errors: [] }

# markdown over 4,999 characters
{ errors: [:too_long] }

# markdown includes unsupported markdown syntax (in this case level headings)
{ errors: [:heading_levels] }

# markdown is too long and has multiple unsupported markdown syntax
{ errors: [:too_long, :heading_levels, :used_hrule, :used_block_quote, :used_emphasis] }
```

Trello: https://trello.com/c/16f0EohC/984-add-validations-warnings-to-govuk-forms-markdown-gem