### PR TITLE
Disallow indented code blocks

### DIFF
--- a/lib/govuk-forms-markdown/renderer.rb
+++ b/lib/govuk-forms-markdown/renderer.rb
@@ -43,6 +43,11 @@ module GovukFormsMarkdown
       nil
     end
 
+    def codespan(code)
+      add_to_error(:used_codespan)
+      code
+    end
+
     def emphasis(text)
       add_to_error(:used_emphasis)
       text

--- a/lib/govuk-forms-markdown/validator.rb
+++ b/lib/govuk-forms-markdown/validator.rb
@@ -27,7 +27,7 @@ module GovukFormsMarkdown
       return nil if markdown.nil? || markdown.empty?
 
       renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } })
-      Redcarpet::Markdown.new(renderer, no_intra_emphasis: true).render(markdown)
+      Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, disable_indented_code_blocks: true).render(markdown)
       renderer.errors if renderer.errors.any?
     end
   end

--- a/lib/govuk_forms_markdown.rb
+++ b/lib/govuk_forms_markdown.rb
@@ -9,7 +9,7 @@ module GovukFormsMarkdown
 
   def self.render(markdown)
     renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } })
-    Redcarpet::Markdown.new(renderer, no_intra_emphasis: true).render(markdown).strip
+    Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, disable_indented_code_blocks: true).render(markdown).strip
   end
 
   def self.validate(markdown)

--- a/spec/govuk-forms-markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk-forms-markdown/govuk_forms_markdown_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe GovukFormsMarkdown do
       expect(render("---")).to eq ""
     end
 
+    it "does not render code blocks" do
+      expect(render("    An indented code block")).to eq "<p class=\"govuk-body\">    An indented code block</p>"
+    end
+
     context "when unsafe content is used it should be escaped" do
       it "renders escaped H2s and GOV.UK classes" do
         expect(render("## <script>alert('Hacked');</script>")).to eq('<h2 class="govuk-heading-m">&lt;script&gt;alert(&#39;Hacked&#39;);&lt;/script&gt;</h2>')

--- a/spec/govuk-forms-markdown/renderer/codespan_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/codespan_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe GovukFormsMarkdown::Renderer, "#codespan " do
+  subject(:renderer) { described_class.new }
+
+  it "does not format codespan" do
+    expect(renderer.codespan("color: rebeccapurple;")).to eq "color: rebeccapurple;"
+  end
+
+  describe "rendering errors" do
+    it "does log an error for codespan being used" do
+      renderer.codespan("color: rebeccapurple;")
+      expect(renderer.errors).to eq([:used_codespan])
+    end
+
+    context "when codespan is called multiple times in a single render" do
+      it "returns the warning exactly once" do
+        renderer.codespan("color: rebeccapurple;")
+        renderer.codespan("color: rebeccapurple;")
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:used_codespan])
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath


### PR DESCRIPTION
Indented code blocks were being rendered by Redcarpet (you can reproduce this by putting four spaces or an indent character at the beginning of a line and previewing). This PR switches them off.

Also adds a renderer method to deal with inline code tags (e.g. `inline code`).