### PR TITLE
Bump gem from 0.3.0 to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Released
 
+### [0.3.1] - 2023-09-22
+
+- Disallow indented code blocks [#15](https://github.com/alphagov/govuk-forms-markdown/pull/15)
+
 ### [0.3.0] - 2023-08-30
 
 - Add a Validator check if markdown is not too long or using unsupported markdown syntax [#13](https://github.com/alphagov/govuk-forms-markdown/pull/13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-forms-markdown (0.3.0)
+    govuk-forms-markdown (0.3.1)
       redcarpet (~> 3.6)
 
 GEM

--- a/lib/govuk-forms-markdown/version.rb
+++ b/lib/govuk-forms-markdown/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukFormsMarkdown
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
This is a patch release since it's not changing the public/documented API of our gem. See release notes.