### PR TITLE
Let users configure whether headings are allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Released
 
+### [0.4.0] - 2023-12-24
+
+- Let users configure whether headings are allowed [#17](https://github.com/alphagov/govuk-forms-markdown/pull/17)
+
 ### [0.3.1] - 2023-09-22
 
 - Disallow indented code blocks [#15](https://github.com/alphagov/govuk-forms-markdown/pull/15)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-forms-markdown (0.3.1)
+    govuk-forms-markdown (0.4.0)
       redcarpet (~> 3.6)
 
 GEM

--- a/lib/govuk-forms-markdown/renderer.rb
+++ b/lib/govuk-forms-markdown/renderer.rb
@@ -6,8 +6,9 @@ module GovukFormsMarkdown
 
     attr_reader :errors
 
-    def initialize(options = {})
+    def initialize(options = {}, allow_headings: true)
       super options
+      @allow_headings = allow_headings
       @errors = []
     end
 
@@ -17,7 +18,10 @@ module GovukFormsMarkdown
                      when 3 then "s"
                      end
 
-      if heading_size.nil?
+      if @allow_headings == false
+        add_to_error(:headings_not_allowed)
+        paragraph(text)
+      elsif heading_size.nil?
         add_to_error(:heading_levels)
         paragraph(text)
       else

--- a/lib/govuk-forms-markdown/validator.rb
+++ b/lib/govuk-forms-markdown/validator.rb
@@ -9,8 +9,9 @@ module GovukFormsMarkdown
   class Validator
     attr_accessor :markdown, :errors
 
-    def initialize(markdown = "")
+    def initialize(markdown = "", allow_headings: true)
       @markdown = markdown
+      @allow_headings = allow_headings
     end
 
     def validate
@@ -26,7 +27,7 @@ module GovukFormsMarkdown
     def validate_tags
       return nil if markdown.nil? || markdown.empty?
 
-      renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } })
+      renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } }, allow_headings: @allow_headings)
       Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, disable_indented_code_blocks: true).render(markdown)
       renderer.errors if renderer.errors.any?
     end

--- a/lib/govuk-forms-markdown/version.rb
+++ b/lib/govuk-forms-markdown/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukFormsMarkdown
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/lib/govuk_forms_markdown.rb
+++ b/lib/govuk_forms_markdown.rb
@@ -7,12 +7,12 @@ require_relative "./govuk-forms-markdown/validator"
 module GovukFormsMarkdown
   class Error < StandardError; end
 
-  def self.render(markdown)
-    renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } })
+  def self.render(markdown, allow_headings: true)
+    renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } }, allow_headings: allow_headings)
     Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, disable_indented_code_blocks: true).render(markdown).strip
   end
 
-  def self.validate(markdown)
-    GovukFormsMarkdown::Validator.new(markdown).validate
+  def self.validate(markdown, allow_headings: true)
+    GovukFormsMarkdown::Validator.new(markdown, allow_headings: allow_headings).validate
   end
 end

--- a/spec/govuk-forms-markdown/renderer/header_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/header_spec.rb
@@ -2,10 +2,13 @@
 
 # rubocop:disable RSpec/FilePath
 RSpec.describe GovukFormsMarkdown::Renderer, "#header" do
-  subject(:renderer) { described_class.new }
+  subject(:renderer) { described_class.new(allow_headings: allow_headings) }
+
+  let(:allow_headings) { true }
 
   non_supported_heading_levels = [1, 4, 5, 6]
   supported_heading_levels = [2, 3]
+  all_heading_levels = non_supported_heading_levels + supported_heading_levels
 
   context "when using non-supported heading levels" do
     non_supported_heading_levels.each do |level|
@@ -47,6 +50,28 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#header" do
 
         expect(renderer.errors.length).to eq 1
         expect(renderer.errors).to eq([:heading_levels])
+      end
+    end
+
+    context "when headings are not allowed" do
+      let(:allow_headings) { false }
+
+      all_heading_levels.each do |level|
+        it "logs a warning for heading level #{level}" do
+          renderer.header("Heading level #{level}", level)
+          expect(renderer.errors).to eq([:headings_not_allowed])
+        end
+      end
+
+      context "when header is called multiple times in a single render" do
+        it "returns only 1 single warning for that one render" do
+          all_heading_levels.each do |level|
+            renderer.header("Heading level #{level}", level)
+          end
+
+          expect(renderer.errors.length).to eq 1
+          expect(renderer.errors).to eq([:headings_not_allowed])
+        end
       end
     end
   end

--- a/spec/govuk-forms-markdown/validator/validator_spec.rb
+++ b/spec/govuk-forms-markdown/validator/validator_spec.rb
@@ -2,7 +2,8 @@
 
 # rubocop:disable RSpec/FilePath
 RSpec.describe GovukFormsMarkdown::Validator do
-  let(:validator) { described_class.new(markdown) }
+  let(:validator) { described_class.new(markdown, allow_headings: allow_headings) }
+  let(:allow_headings) { true }
 
   describe "#validate_length" do
     context "when markdown is empty string" do
@@ -82,6 +83,15 @@ RSpec.describe GovukFormsMarkdown::Validator do
 
       it "returns all errors" do
         expect(validator.validate_tags).to eq([:unsupported_tags_used])
+      end
+
+      context "when headings are disallowed" do
+        let(:allow_headings) { false }
+        let(:markdown) { "## A level-2 heading" }
+
+        it "returns all errors" do
+          expect(validator.validate_tags).to eq([:unsupported_tags_used])
+        end
       end
     end
   end


### PR DESCRIPTION
Depending where the resulting markdown is rendered, we may want to stop our markdown renderer from rendering headings. This PR adds a flag for this to the renderer and validator, so we can disallow headings in those contexts when necessary.