### PR TITLE
add "(opens in new tab)" suffix to links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Released
 
-### [0.4.0] - 2023-12-24
+### [0.5.0] - 2023-12-18
+
+- Add `(opens in new tab)` suffix to link text [#13](https://github.com/alphagov/govuk-forms-markdown/pull/18)
+
+### [0.4.0] - 2023-11-24
 
 - Let users configure whether headings are allowed [#17](https://github.com/alphagov/govuk-forms-markdown/pull/17)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-forms-markdown (0.4.0)
+    govuk-forms-markdown (0.5.0)
       redcarpet (~> 3.6)
 
 GEM

--- a/lib/govuk-forms-markdown/renderer.rb
+++ b/lib/govuk-forms-markdown/renderer.rb
@@ -69,7 +69,7 @@ module GovukFormsMarkdown
 
     def link(link, title, content)
       title_attribute = title.nil? ? "" : " title=\"#{title}\""
-      %(<a href="#{link}" class="govuk-link"#{title_attribute} rel="noreferrer noopener" target="_blank">#{content}</a>)
+      %(<a href="#{link}" class="govuk-link"#{title_attribute} rel="noreferrer noopener" target="_blank">#{content} (opens in new tab)</a>)
     end
 
     def list(contents, list_type)

--- a/lib/govuk-forms-markdown/version.rb
+++ b/lib/govuk-forms-markdown/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukFormsMarkdown
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/govuk-forms-markdown/renderer/link_spec.rb
+++ b/spec/govuk-forms-markdown/renderer/link_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe GovukFormsMarkdown::Renderer, "#link" do
 
   context "when there is no title" do
     it "renders a link" do
-      expect(renderer.link("https://example.com", nil, "Link content").strip).to eq "<a href=\"https://example.com\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">Link content</a>"
+      expect(renderer.link("https://example.com", nil, "Link content").strip).to eq "<a href=\"https://example.com\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">Link content (opens in new tab)</a>"
     end
   end
 
   context "when there is a title" do
     it "renders a link" do
-      expect(renderer.link("https://example.com", "Link title", "Link content").strip).to eq "<a href=\"https://example.com\" class=\"govuk-link\" title=\"Link title\" rel=\"noreferrer noopener\" target=\"_blank\">Link content</a>"
+      expect(renderer.link("https://example.com", "Link title", "Link content").strip).to eq "<a href=\"https://example.com\" class=\"govuk-link\" title=\"Link title\" rel=\"noreferrer noopener\" target=\"_blank\">Link content (opens in new tab)</a>"
     end
   end
 end


### PR DESCRIPTION
Links should have `(opens in new tab)` suffix so that users can expect the link to open in a new tab.

see https://design-system.service.gov.uk/styles/links/#external-links