### PR TITLE
Bump Ruby from 3.1.2 to 3.3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1.2'
+          - '3.3.1'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Bump the version of Ruby used for continuous integration tests.