### PR TITLE
Add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+.DS_Store


### PR DESCRIPTION
.DS_Store files are macOS-specific metadata files that there is no need to share, so shouldn't be tracked by git