### PR TITLE
Normalize platforms in Bundler lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   arm64-darwin-24
   x86_64-darwin-22
   x86_64-linux
@@ -115,4 +116,4 @@ DEPENDENCIES
   rubocop-govuk
 
 BUNDLED WITH
-   2.4.7
+   2.6.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,10 +103,9 @@ GEM
     unicode-display_width (2.6.0)
 
 PLATFORMS
-  arm64-darwin-22
-  arm64-darwin-23
-  arm64-darwin-24
-  x86_64-darwin-22
+  arm64-darwin
+  ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
This PR copies over some of the changes alphagov/forms-admin#1727, including bumping the version of Bundler and cleaning up the list of platforms in the lockfile with bundle lock --normalize-platforms.