### PR TITLE
Schedule dependabot updates every Sunday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     open-pull-requests-limit: 10
+
 # Maintain dependencies for Ruby
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot updates are getting burdensome. Dependabot docs recommend [scheduling updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#controlling-the-frequency-and-timings-of-dependency-updates) to reduce this workload somewhat. The goal here is that the week's dependabot PRs would all be raised at the beginning of the working week, giving us time to sort them out before more get raised the following week. Security updates should still get raised along with associated security alerts.

In future we could also use groups to e.g. gather all dev dependencies into a single PR.