### PR TITLE
Bump version number to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Released
 
+### [0.6.0] - 2025-06-10
+
+- Add .DS_Store files to .gitignore [#20](https://github.com/alphagov/govuk-forms-markdown/pull/20)
+- Create dependabot.yml [#24](https://github.com/alphagov/govuk-forms-markdown/pull/24)
+- Schedule dependabot updates every Sunday [#31](https://github.com/alphagov/govuk-forms-markdown/pull/31)
+- Normalize platforms in Bundler lockfile [#29](https://github.com/alphagov/govuk-forms-markdown/pull/29)
+- Bump supported minimum version of Ruby to 3.4.1 [#30](https://github.com/alphagov/govuk-forms-markdown/pull/30)
+- Dependency updates
+
 ### [0.5.0] - 2023-12-18
 
 - Add `(opens in new tab)` suffix to link text [#13](https://github.com/alphagov/govuk-forms-markdown/pull/18)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-forms-markdown (0.5.0)
+    govuk-forms-markdown (0.6.0)
       redcarpet (~> 3.6)
 
 GEM

--- a/lib/govuk-forms-markdown/version.rb
+++ b/lib/govuk-forms-markdown/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukFormsMarkdown
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
It's been a while since we've published updates - this commit updates the changelog and bumps the version number to 0.6.0 in preparation for publishing a release.