### PR TITLE
Bump supported minimum version of Ruby to 3.4.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.4.1'
+          - '3.4.6'
 
     steps:
     - uses: actions/checkout@v5

--- a/govuk-forms-markdown.gemspec
+++ b/govuk-forms-markdown.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "This gem renders the limited subset of Markdown syntax supported by GOV.UK Forms."
   spec.homepage = "https://github.com/alphagov/govuk-forms-markdown"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.4.1"
+  spec.required_ruby_version = ">= 3.4.6"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 


### PR DESCRIPTION
Bumps Ruby from 3.4.1 to 3.4.6

Trello: https://trello.com/c/iAQTE0RU/2619-bump-ruby-version-to-346