### PR TITLE
Add plain text email renderer

### DIFF
--- a/lib/govuk-forms-markdown/plain_text_renderer.rb
+++ b/lib/govuk-forms-markdown/plain_text_renderer.rb
@@ -1,0 +1,89 @@
+module GovukFormsMarkdown
+  class PlainTextRenderer < ::Redcarpet::Render::Safe
+    class Error < StandardError; end
+
+    attr_reader :errors
+
+    # Redcarpet builds lists in two passes (list_item, then list). We tag each item
+    # with this unlikely string and replace it with bullets or numbers in #list.
+    MAGIC_SEQUENCE = "🇬🇧🕶️📋️".freeze
+
+    def initialize(options = {})
+      super options
+      @errors = []
+    end
+
+    def header(text, _header_level)
+      paragraph(text)
+    end
+
+    def paragraph(text)
+      if text.to_s.strip != ""
+        (linebreak * 2) + text
+      else
+        ""
+      end
+    end
+
+    def block_quote(quote)
+      quote
+    end
+
+    def hrule
+      add_to_error(:used_hrule)
+      nil
+    end
+
+    def codespan(code)
+      add_to_error(:used_codespan)
+      code
+    end
+
+    def emphasis(text)
+      add_to_error(:used_emphasis)
+      text
+    end
+
+    def double_emphasis(text)
+      add_to_error(:used_emphasis)
+      text
+    end
+
+    def triple_emphasis(text)
+      add_to_error(:used_emphasis)
+      text
+    end
+
+    def link(link, title, content)
+      result = content.to_s
+      result += " (#{title})" unless title.nil? || title == ""
+      "#{result}: #{link}"
+    end
+
+    def list(contents, list_type)
+      counter = 0
+      if list_type == :ordered
+        contents.gsub(MAGIC_SEQUENCE) { "#{counter += 1}." }
+      elsif list_type == :unordered
+        contents.gsub(MAGIC_SEQUENCE, "•")
+      else
+        raise GovukFormsMarkdown::Error, "Unexpected type #{list_type.inspect}"
+      end
+    end
+
+    def list_item(text, _list_type)
+      "#{linebreak}#{MAGIC_SEQUENCE} #{text.strip}"
+    end
+
+  private
+
+    def add_to_error(error)
+      symbolized_error = error.to_sym
+      errors << symbolized_error unless errors.include?(symbolized_error)
+    end
+
+    def linebreak
+      "\n"
+    end
+  end
+end

--- a/lib/govuk_forms_markdown.rb
+++ b/lib/govuk_forms_markdown.rb
@@ -2,6 +2,7 @@ require "redcarpet"
 
 require_relative "./govuk-forms-markdown/version"
 require_relative "./govuk-forms-markdown/renderer"
+require_relative "./govuk-forms-markdown/plain_text_renderer"
 require_relative "./govuk-forms-markdown/validator"
 
 module GovukFormsMarkdown
@@ -11,6 +12,11 @@ module GovukFormsMarkdown
     raise GovukFormsMarkdown::Error, "Unsupported locale \"#{locale}\"" unless %w[en cy].include?(locale)
 
     renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } }, allow_headings:, locale:)
+    Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, disable_indented_code_blocks: true).render(markdown).strip
+  end
+
+  def self.render_plain_text(markdown)
+    renderer = PlainTextRenderer.new
     Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, disable_indented_code_blocks: true).render(markdown).strip
   end
 

--- a/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
@@ -145,6 +145,42 @@ RSpec.describe GovukFormsMarkdown do
     end
   end
 
+  describe ".render_plain_text" do
+    it "renders a paragraph as plain text" do
+      expect(described_class.render_plain_text("abc")).to eq("abc")
+    end
+
+    it "renders headings as a paragraph" do
+      expect(described_class.render_plain_text("# Heading level 1")).to eq("Heading level 1")
+    end
+
+    it "renders unordered lists with bullets" do
+      input = <<~MARKDOWN
+        * abc def
+        * xyz
+      MARKDOWN
+
+      expect(described_class.render_plain_text(input)).to eq("• abc def\n• xyz")
+    end
+
+    it "renders ordered lists with numbers" do
+      input = <<~MARKDOWN
+        1. abc def
+        2. xyz
+      MARKDOWN
+
+      expect(described_class.render_plain_text(input)).to eq("1. abc def\n2. xyz")
+    end
+
+    it "renders links as text: url" do
+      expect(described_class.render_plain_text("[Gov.uk](https://www.gov.uk)")).to eq("Gov.uk: https://www.gov.uk")
+    end
+
+    it "does not render hrules" do
+      expect(described_class.render_plain_text("---")).to eq("")
+    end
+  end
+
   describe ".validate" do
     it "returns JSON with error key being an empty array" do
       expect(validate("## Heading level 2")[:errors]).to be_empty

--- a/spec/govuk_forms_markdown/plain_text_renderer/block_quote_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/block_quote_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#block_quote" do
+  subject(:renderer) { described_class.new }
+
+  it "returns the quoted text unmodified" do
+    expect(renderer.block_quote("This is a quote")).to eq "This is a quote"
+  end
+
+  describe "rendering errors" do
+    it "does not log an error for block quote being used" do
+      renderer.block_quote("This is a quote")
+      expect(renderer.errors).to be_empty
+    end
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/codespan_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/codespan_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#codespan" do
+  subject(:renderer) { described_class.new }
+
+  it "returns the code and logs an error" do
+    expect(renderer.codespan("color: rebeccapurple;")).to eq "color: rebeccapurple;"
+    expect(renderer.errors).to eq([:used_codespan])
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/double_emphasis_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/double_emphasis_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#double_emphasis" do
+  subject(:renderer) { described_class.new }
+
+  it "does not format double_emphasis and logs an error" do
+    expect(renderer.double_emphasis("very important text")).to eq "very important text"
+    expect(renderer.errors).to eq([:used_emphasis])
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/emphasis_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/emphasis_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#emphasis" do
+  subject(:renderer) { described_class.new }
+
+  it "does not format emphasis and logs an error" do
+    expect(renderer.emphasis("important text")).to eq "important text"
+    expect(renderer.errors).to eq([:used_emphasis])
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/header_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/header_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#header" do
+  subject(:renderer) { described_class.new }
+
+  it "renders headings as a paragraph" do
+    expect(renderer.header("A heading", 1)).to eq "\n\n\A heading"
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/hrule_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/hrule_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#hrule" do
+  subject(:renderer) { described_class.new }
+
+  it "does not render hrule and logs an error" do
+    expect(renderer.hrule).to be_nil
+    expect(renderer.errors).to eq([:used_hrule])
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/link_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/link_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#link" do
+  subject(:renderer) { described_class.new }
+
+  context "when there is no title" do
+    it "renders a link" do
+      expect(renderer.link("https://example.com", nil, "Link content")).to eq("Link content: https://example.com")
+    end
+  end
+
+  context "when there is a title" do
+    it "renders a link" do
+      expect(renderer.link("https://example.com", "Link title", "Link content")).to eq("Link content (Link title): https://example.com")
+    end
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/list_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/list_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#list" do
+  subject(:renderer) { described_class.new }
+
+  context "when displaying an unordered list" do
+    it "renders bullets for list items" do
+      contents = renderer.list_item("abc", :unordered) + renderer.list_item("xyz", :unordered)
+      expect(renderer.list(contents, :unordered)).to eq("\n• abc\n• xyz")
+    end
+  end
+
+  context "when displaying an ordered list" do
+    it "renders numbered markers for list items" do
+      contents = renderer.list_item("abc", :ordered) + renderer.list_item("xyz", :ordered)
+      expect(renderer.list(contents, :ordered)).to eq("\n1. abc\n2. xyz")
+    end
+  end
+
+  context "when displaying an unsupported list" do
+    it "raises an error" do
+      expect { renderer.list("My list of items", :not_supported_type) }.to raise_error(GovukFormsMarkdown::Error, "Unexpected type :not_supported_type")
+    end
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/paragraph_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/paragraph_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#paragraph" do
+  subject(:renderer) { described_class.new }
+
+  it "renders a paragraph as plain text" do
+    expect(renderer.paragraph("This is some paragraph text")).to eq "\n\nThis is some paragraph text"
+  end
+end

--- a/spec/govuk_forms_markdown/plain_text_renderer/triple_emphasis_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/triple_emphasis_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#triple_emphasis" do
+  subject(:renderer) { described_class.new }
+
+  it "does not format triple_emphasis and logs an error" do
+    expect(renderer.triple_emphasis("extremely important text")).to eq "extremely important text"
+    expect(renderer.errors).to eq([:used_emphasis])
+  end
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/hCWhyMOm

Add a renderer that formats markdown for use in plain text emails.

This ignores most markdown elements, and just renders them as paragraph, with the exception of links which are rendered as "text: url" and lists which are rendered with bullet points or numberd.

This follows similar rules to Notify's plain text email markdown renderer, except it doesn't add underlines to headings as we haven't done that in the existing plain text emails we send: https://github.com/alphagov/notifications-utils/blob/ee41d2202592cf80f4148447cfe07283ee1f03e3/notifications_utils/markdown.py