### PR TITLE
Add renderer for markdown in emails

### DIFF
--- a/lib/govuk-forms-markdown/email_renderer.rb
+++ b/lib/govuk-forms-markdown/email_renderer.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module GovukFormsMarkdown
+  # Uses the formatting from Notify, defined in
+  # https://github.com/alphagov/notifications-utils/blob/fad26d684f87a832cc54cee072844ad5dccd2305/notifications_utils/markdown.py
+  class EmailRenderer < ::Redcarpet::Render::Safe
+    class Error < StandardError; end
+
+    attr_reader :errors
+
+    def initialize(options = {}, allow_headings: true)
+      super options
+      @allow_headings = allow_headings
+      @errors = []
+    end
+
+    def header(text, header_level)
+      if !@allow_headings
+        add_to_error(:headings_not_allowed)
+        paragraph(text)
+      elsif header_level == 2
+        <<~HTML
+          <h2 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">
+            #{text}
+          </h2>
+        HTML
+      elsif header_level == 3
+        <<~HTML
+          <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+            #{text}
+          </h3>
+        HTML
+      else
+        add_to_error(:heading_levels)
+        paragraph(text)
+      end
+    end
+
+    def paragraph(text)
+      <<~HTML
+        <p>#{text}</p>
+      HTML
+    end
+
+    def block_quote(quote)
+      add_to_error(:used_block_quote)
+      paragraph(quote)
+    end
+
+    def hrule
+      add_to_error(:used_hrule)
+      nil
+    end
+
+    def codespan(code)
+      add_to_error(:used_codespan)
+      code
+    end
+
+    def emphasis(text)
+      add_to_error(:used_emphasis)
+      text
+    end
+
+    def double_emphasis(text)
+      add_to_error(:used_emphasis)
+      text
+    end
+
+    def triple_emphasis(text)
+      add_to_error(:used_emphasis)
+      text
+    end
+
+    def link(link, title, content)
+      title_attribute = title.nil? ? "" : " title=\"#{title}\""
+      <<~HTML.chomp
+        <a href="#{link}"#{title_attribute} style="word-wrap: break-word; color: #1D70B8;">#{content}</a>
+      HTML
+    end
+
+    def autolink(link, link_type)
+      href = link_type == :email ? "mailto:#{link}" : link
+      <<~HTML.chomp
+        <a href="#{href}" style="word-wrap: break-word; color: #1D70B8;">#{link}</a>
+      HTML
+    end
+
+    def list(contents, list_type)
+      if list_type == :unordered
+        <<~HTML
+          <table role="presentation" style="padding: 0 0 20px 0;">
+            <tr>
+              <td style="font-family: Helvetica, Arial, sans-serif;">
+                <ul style="Margin: 0 0 0 20px; padding: 0; list-style-type: disc;">
+                  #{contents}
+                </ul>
+              </td>
+            </tr>
+          </table>
+        HTML
+      elsif list_type == :ordered
+        <<~HTML
+          <table role="presentation" style="padding: 0 0 20px 0;">
+            <tr>
+              <td style="font-family: Helvetica, Arial, sans-serif;">
+                <ol style="Margin: 0 0 0 20px; padding: 0; list-style-type: decimal;">
+                  #{contents}
+                </ol>
+              </td>
+            </tr>
+          </table>
+        HTML
+      else
+        raise GovukFormsMarkdown::Error, "Unexpected type #{list_type.inspect}"
+      end
+    end
+
+    def list_item(text, _list_type)
+      <<~HTML
+        <li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+          #{text}
+        </li>
+      HTML
+    end
+
+  private
+
+    def add_to_error(error)
+      symbolized_error = error.to_sym
+      errors << symbolized_error unless errors.include?(symbolized_error)
+    end
+  end
+end

--- a/lib/govuk_forms_markdown.rb
+++ b/lib/govuk_forms_markdown.rb
@@ -3,6 +3,7 @@ require "redcarpet"
 require_relative "./govuk-forms-markdown/version"
 require_relative "./govuk-forms-markdown/renderer"
 require_relative "./govuk-forms-markdown/plain_text_renderer"
+require_relative "./govuk-forms-markdown/email_renderer"
 require_relative "./govuk-forms-markdown/validator"
 
 module GovukFormsMarkdown
@@ -12,6 +13,11 @@ module GovukFormsMarkdown
     raise GovukFormsMarkdown::Error, "Unsupported locale \"#{locale}\"" unless %w[en cy].include?(locale)
 
     renderer = GovukFormsMarkdown::Renderer.new({ link_attributes: { class: "govuk-link", rel: "noreferrer noopener", target: "_blank" } }, allow_headings:, locale:)
+    Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, disable_indented_code_blocks: true).render(markdown).strip
+  end
+
+  def self.render_for_email(markdown, allow_headings: true)
+    renderer = GovukFormsMarkdown::EmailRenderer.new(allow_headings:)
     Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, disable_indented_code_blocks: true).render(markdown).strip
   end
 

--- a/spec/govuk_forms_markdown/email_renderer/autolink_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/autolink_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#autolink" do
+  subject(:renderer) { described_class.new }
+
+  context "when autolinking a URL" do
+    it "renders a styled link" do
+      expected = <<~HTML.strip
+        <a href="https://example.com" style="word-wrap: break-word; color: #1D70B8;">https://example.com</a>
+      HTML
+
+      expect(renderer.autolink("https://example.com", :url)).to eq expected
+    end
+  end
+
+  context "when autolinking an email address" do
+    it "renders a mailto styled link" do
+      expected = <<~HTML.strip
+        <a href="mailto:noreply@example.com" style="word-wrap: break-word; color: #1D70B8;">noreply@example.com</a>
+      HTML
+
+      expect(renderer.autolink("noreply@example.com", :email)).to eq expected
+    end
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/block_quote_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/block_quote_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#block_quote" do
+  subject(:renderer) { described_class.new }
+
+  it "does not format blockquote (renders as paragraph)" do
+    expect(renderer.block_quote("This is a quote").strip).to eq "<p>This is a quote</p>"
+  end
+
+  describe "rendering errors" do
+    it "does log an error for block quote being used" do
+      renderer.block_quote("This is a quote")
+      expect(renderer.errors).to eq([:used_block_quote])
+    end
+
+    context "when block quote is called multiple times in a single render" do
+      it "returns only 1 single warning for that one render" do
+        renderer.block_quote("This is a quote")
+        renderer.block_quote("This is a quote")
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:used_block_quote])
+      end
+    end
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/codespan_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/codespan_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#codespan" do
+  subject(:renderer) { described_class.new }
+
+  it "returns the code unchanged" do
+    expect(renderer.codespan("code_snippet")).to eq "code_snippet"
+  end
+
+  it "logs an error for using codespan" do
+    renderer.codespan("code_snippet")
+    expect(renderer.errors).to eq([:used_codespan])
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/double_emphasis_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/double_emphasis_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#double_emphasis" do
+  subject(:renderer) { described_class.new }
+
+  it "returns the text unchanged" do
+    expect(renderer.double_emphasis("strong")).to eq "strong"
+  end
+
+  it "logs an error for using double_emphasis" do
+    renderer.double_emphasis("strong")
+    expect(renderer.errors).to eq([:used_emphasis])
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/emphasis_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/emphasis_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#emphasis" do
+  subject(:renderer) { described_class.new }
+
+  it "returns the text unchanged" do
+    expect(renderer.emphasis("emphasised")).to eq "emphasised"
+  end
+
+  it "logs an error for using emphasis" do
+    renderer.emphasis("emphasised")
+    expect(renderer.errors).to eq([:used_emphasis])
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/header_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/header_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#header" do
+  subject(:renderer) { described_class.new({}, allow_headings:) }
+
+  let(:allow_headings) { true }
+
+  non_supported_heading_levels = [1, 4, 5, 6]
+  supported_heading_levels = [2, 3]
+  all_heading_levels = non_supported_heading_levels + supported_heading_levels
+
+  context "when using non-supported heading levels" do
+    non_supported_heading_levels.each do |level|
+      it "does not format heading level #{level}" do
+        expect(renderer.header("Heading level #{level}", level).strip).to eq("<p>Heading level #{level}</p>")
+      end
+    end
+  end
+
+  context "when using supported heading levels" do
+    it "formats heading level 2" do
+      expected = <<~HTML.strip
+        <h2 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">
+          Heading level 2
+        </h2>
+      HTML
+
+      expect(renderer.header("Heading level 2", 2).strip).to eq expected
+    end
+
+    it "formats heading level 3" do
+      expected = <<~HTML.strip
+        <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+          Heading level 3
+        </h3>
+      HTML
+
+      expect(renderer.header("Heading level 3", 3).strip).to eq expected
+    end
+  end
+
+  describe "rendering errors" do
+    supported_heading_levels.each do |level|
+      it "does not log a warning for heading level #{level}" do
+        renderer.header("Heading level #{level}", level)
+        expect(renderer.errors).to be_empty
+      end
+    end
+
+    non_supported_heading_levels.each do |level|
+      it "does log a warning for heading level #{level}" do
+        renderer.header("Heading level #{level}", level)
+        expect(renderer.errors).to eq([:heading_levels])
+      end
+    end
+
+    context "when header is called multiple times in a single render" do
+      it "returns only 1 single warning for that one render" do
+        non_supported_heading_levels.each do |level|
+          renderer.header("Heading level #{level}", level)
+        end
+
+        expect(renderer.errors.length).to eq 1
+        expect(renderer.errors).to eq([:heading_levels])
+      end
+    end
+
+    context "when headings are not allowed" do
+      let(:allow_headings) { false }
+
+      all_heading_levels.each do |level|
+        it "logs a warning for heading level #{level}" do
+          renderer.header("Heading level #{level}", level)
+          expect(renderer.errors).to eq([:headings_not_allowed])
+        end
+      end
+
+      context "when header is called multiple times in a single render" do
+        it "returns only 1 single warning for that one render" do
+          all_heading_levels.each do |level|
+            renderer.header("Heading level #{level}", level)
+          end
+
+          expect(renderer.errors.length).to eq 1
+          expect(renderer.errors).to eq([:headings_not_allowed])
+        end
+      end
+    end
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/hrule_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/hrule_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#hrule" do
+  subject(:renderer) { described_class.new }
+
+  it "returns nil for hrule" do
+    expect(renderer.hrule).to be_nil
+  end
+
+  it "logs an error for using hrule" do
+    renderer.hrule
+    expect(renderer.errors).to eq([:used_hrule])
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/link_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/link_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#link" do
+  subject(:renderer) { described_class.new }
+
+  context "when there is no title" do
+    it "renders a link" do
+      expected = <<~HTML.strip
+        <a href="https://example.com" style="word-wrap: break-word; color: #1D70B8;">Link content</a>
+      HTML
+
+      expect(renderer.link("https://example.com", nil, "Link content")).to eq expected
+    end
+  end
+
+  context "when there is a title" do
+    it "renders a link with a title attribute" do
+      expected = <<~HTML.strip
+        <a href="https://example.com" title="Link title" style="word-wrap: break-word; color: #1D70B8;">Link content</a>
+      HTML
+
+      expect(renderer.link("https://example.com", "Link title", "Link content")).to eq expected
+    end
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/list_item_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/list_item_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#list_item" do
+  subject(:renderer) { described_class.new }
+
+  it "renders a list item with inline styles" do
+    expected = <<~HTML.strip
+      <li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C;">
+        An item
+      </li>
+    HTML
+
+    expect(renderer.list_item("An item", :unordered).strip).to eq expected
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/list_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/list_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#list" do
+  subject(:renderer) { described_class.new }
+
+  context "when displaying an unordered list" do
+    it "wraps contents in a table and ul with email-safe styles" do
+      contents = "A list of values"
+      expected_html = <<~HTML
+        <table role="presentation" style="padding: 0 0 20px 0;">
+          <tr>
+            <td style="font-family: Helvetica, Arial, sans-serif;">
+              <ul style="Margin: 0 0 0 20px; padding: 0; list-style-type: disc;">
+                #{contents}
+              </ul>
+            </td>
+          </tr>
+        </table>
+      HTML
+
+      expect(renderer.list(contents, :unordered)).to eq expected_html
+    end
+  end
+
+  context "when displaying an ordered list" do
+    it "wraps contents in a table and ol with email-safe styles" do
+      contents = "A list of values"
+      expected_html = <<~HTML
+        <table role="presentation" style="padding: 0 0 20px 0;">
+          <tr>
+            <td style="font-family: Helvetica, Arial, sans-serif;">
+              <ol style="Margin: 0 0 0 20px; padding: 0; list-style-type: decimal;">
+                #{contents}
+              </ol>
+            </td>
+          </tr>
+        </table>
+      HTML
+
+      expect(renderer.list(contents, :ordered)).to eq expected_html
+    end
+  end
+
+  context "when displaying an unsupported list" do
+    it "raises an error" do
+      expect { renderer.list("My list of items", :not_supported_type) }.to raise_error(GovukFormsMarkdown::Error, "Unexpected type :not_supported_type")
+    end
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/paragraph_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/paragraph_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#paragraph" do
+  subject(:renderer) { described_class.new }
+
+  it "wraps text in p tags" do
+    expect(renderer.paragraph("Some text").strip).to eq "<p>Some text</p>"
+  end
+
+  it "returns empty p for empty string" do
+    expect(renderer.paragraph("").strip).to eq "<p></p>"
+  end
+end

--- a/spec/govuk_forms_markdown/email_renderer/triple_emphasis_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/triple_emphasis_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#triple_emphasis" do
+  subject(:renderer) { described_class.new }
+
+  it "returns the text unchanged" do
+    expect(renderer.triple_emphasis("very strong")).to eq "very strong"
+  end
+
+  it "logs an error for using triple_emphasis" do
+    renderer.triple_emphasis("very strong")
+    expect(renderer.errors).to eq([:used_emphasis])
+  end
+end

--- a/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
@@ -181,6 +181,60 @@ RSpec.describe GovukFormsMarkdown do
     end
   end
 
+  describe ".render_for_email" do
+    it "renders H2s with email inline styles" do
+      expected_html = <<~HTML
+        <h2 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">
+          Top heading
+        </h2>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("## Top heading"), expected_html)
+    end
+
+    it "renders H3s with email inline styles" do
+      expected_html = <<~HTML
+        <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+          A heading
+        </h3>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("### A heading"), expected_html)
+    end
+
+    it "renders paragraphs" do
+      expect(described_class.render_for_email("abc")).to eq("<p>abc</p>")
+    end
+
+    it "renders a link" do
+      expected_html = <<~HTML
+        <p><a href="https://www.gov.uk" style="word-wrap: break-word; color: #1D70B8;">Some text</a>.</p>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("[Some text](https://www.gov.uk)."), expected_html)
+    end
+
+    it "renders a URL with email inline styles" do
+      expected_html = <<~HTML
+        <p><a href="https://www.gov.uk/help" style="word-wrap: break-word; color: #1D70B8;">https://www.gov.uk/help</a>.</p>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("<https://www.gov.uk/help>."), expected_html)
+    end
+
+    it "renders an email address with email inline styles" do
+      expected_html = <<~HTML
+        <p><a href="mailto:noreply@gov.uk" style="word-wrap: break-word; color: #1D70B8;">noreply@gov.uk</a></p>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("<noreply@gov.uk>"), expected_html)
+    end
+
+    it "does not render hrules" do
+      expect(described_class.render_for_email("---")).to eq("")
+    end
+  end
+
   describe ".validate" do
     it "returns JSON with error key being an empty array" do
       expect(validate("## Heading level 2")[:errors]).to be_empty


### PR DESCRIPTION
Trello card: https://trello.com/c/hCWhyMOm

We need to format markdown differently for emails as there isn't a stylesheet so we need to include inline styles. We also don't want to render the (opens in new tab) text for links.

Add a renderer for this use case.