### PR TITLE
Add support for additional email formatting

### DIFF
--- a/lib/govuk-forms-markdown/email_renderer.rb
+++ b/lib/govuk-forms-markdown/email_renderer.rb
@@ -30,6 +30,12 @@ module GovukFormsMarkdown
             #{text}
           </h3>
         HTML
+      elsif header_level == 4
+        <<~HTML
+          <h4 style="font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+            #{text}
+          </h4>
+        HTML
       else
         add_to_error(:heading_levels)
         paragraph(text)

--- a/lib/govuk-forms-markdown/email_renderer.rb
+++ b/lib/govuk-forms-markdown/email_renderer.rb
@@ -48,8 +48,9 @@ module GovukFormsMarkdown
     end
 
     def hrule
-      add_to_error(:used_hrule)
-      nil
+      <<~HTML
+        <hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">
+      HTML
     end
 
     def codespan(code)

--- a/lib/govuk-forms-markdown/email_renderer.rb
+++ b/lib/govuk-forms-markdown/email_renderer.rb
@@ -125,11 +125,44 @@ module GovukFormsMarkdown
       HTML
     end
 
+    def inline_callout(text)
+      <<~HTML
+        <div style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6; padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;">
+          <p style="margin: 0 0 20px 0">#{text}</p>
+        </div>
+      HTML
+    end
+
+    def block_callout(text)
+      <<~HTML
+        <div style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6; padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;">
+          #{text}
+        </div>
+      HTML
+    end
+
+    def postprocess(document)
+      document_with_block_callouts = render_block_callouts(document)
+      render_inline_callouts(document_with_block_callouts)
+    end
+
   private
 
     def add_to_error(error)
       symbolized_error = error.to_sym
       errors << symbolized_error unless errors.include?(symbolized_error)
+    end
+
+    def render_block_callouts(text)
+      block_callout_regex = /<p>(?:\^\^\^)<\/p>((.|\s)*)<p>(?:\^\^\^)<\/p>/
+
+      text.gsub(block_callout_regex, block_callout('\1'))
+    end
+
+    def render_inline_callouts(text)
+      inline_callout_regex = /<p>(?:\^)(.*)(?:\^)<\/p>/
+
+      text.gsub(inline_callout_regex, inline_callout('\1'))
     end
   end
 end

--- a/lib/govuk-forms-markdown/plain_text_renderer.rb
+++ b/lib/govuk-forms-markdown/plain_text_renderer.rb
@@ -30,8 +30,7 @@ module GovukFormsMarkdown
     end
 
     def hrule
-      add_to_error(:used_hrule)
-      nil
+      "#{linebreak * 2}---"
     end
 
     def codespan(code)

--- a/lib/govuk-forms-markdown/plain_text_renderer.rb
+++ b/lib/govuk-forms-markdown/plain_text_renderer.rb
@@ -74,6 +74,19 @@ module GovukFormsMarkdown
       "#{linebreak}#{MAGIC_SEQUENCE} #{text.strip}"
     end
 
+    def inline_callout(text)
+      paragraph(text)
+    end
+
+    def block_callout(text)
+      text
+    end
+
+    def postprocess(document)
+      document_with_block_callouts = render_block_callouts(document)
+      render_inline_callouts(document_with_block_callouts)
+    end
+
   private
 
     def add_to_error(error)
@@ -83,6 +96,18 @@ module GovukFormsMarkdown
 
     def linebreak
       "\n"
+    end
+
+    def render_block_callouts(text)
+      block_callout_regex = /(?:\^\^\^)((.|\s)*)(?:\^\^\^)/
+
+      text.gsub(block_callout_regex, block_callout('\1'))
+    end
+
+    def render_inline_callouts(text)
+      inline_callout_regex = /(?:\^)(.*)(?:\^)/
+
+      text.gsub(inline_callout_regex, inline_callout('\1'))
     end
   end
 end

--- a/spec/govuk_forms_markdown/email_renderer/header_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/header_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe GovukFormsMarkdown::EmailRenderer, "#header" do
 
   let(:allow_headings) { true }
 
-  non_supported_heading_levels = [1, 4, 5, 6]
-  supported_heading_levels = [2, 3]
+  non_supported_heading_levels = [1, 5, 6]
+  supported_heading_levels = [2, 3, 4]
   all_heading_levels = non_supported_heading_levels + supported_heading_levels
 
   context "when using non-supported heading levels" do
@@ -36,6 +36,16 @@ RSpec.describe GovukFormsMarkdown::EmailRenderer, "#header" do
       HTML
 
       expect(renderer.header("Heading level 3", 3).strip).to eq expected
+    end
+
+    it "formats heading level 4" do
+      expected = <<~HTML.strip
+        <h4 style="font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+          Heading level 4
+        </h4>
+      HTML
+
+      expect(renderer.header("Heading level 4", 4).strip).to eq expected
     end
   end
 

--- a/spec/govuk_forms_markdown/email_renderer/hrule_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/hrule_spec.rb
@@ -3,12 +3,12 @@
 RSpec.describe GovukFormsMarkdown::EmailRenderer, "#hrule" do
   subject(:renderer) { described_class.new }
 
-  it "returns nil for hrule" do
-    expect(renderer.hrule).to be_nil
+  it "returns a styled horizontal rule" do
+    expect(renderer.hrule).to eq "<hr style=\"border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;\">\n"
   end
 
-  it "logs an error for using hrule" do
+  it "does not log an error for using hrule" do
     renderer.hrule
-    expect(renderer.errors).to eq([:used_hrule])
+    expect(renderer.errors).to be_empty
   end
 end

--- a/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
@@ -176,8 +176,8 @@ RSpec.describe GovukFormsMarkdown do
       expect(described_class.render_plain_text("[Gov.uk](https://www.gov.uk)")).to eq("Gov.uk: https://www.gov.uk")
     end
 
-    it "does not render hrules" do
-      expect(described_class.render_plain_text("---")).to eq("")
+    it "renders horizontal rules as three dashes" do
+      expect(described_class.render_plain_text("---")).to eq("---")
     end
   end
 
@@ -230,8 +230,12 @@ RSpec.describe GovukFormsMarkdown do
       expect_equal_ignoring_ws(described_class.render_for_email("<noreply@gov.uk>"), expected_html)
     end
 
-    it "does not render hrules" do
-      expect(described_class.render_for_email("---")).to eq("")
+    it "renders a styled horizontal rule" do
+      expected_html = <<~HTML
+        <hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("---"), expected_html)
     end
   end
 

--- a/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
@@ -210,6 +210,16 @@ RSpec.describe GovukFormsMarkdown do
       expect_equal_ignoring_ws(described_class.render_for_email("### A heading"), expected_html)
     end
 
+    it "renders H4s with email inline styles" do
+      expected_html = <<~HTML
+        <h4 style="font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+          A heading
+        </h4>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("#### A heading"), expected_html)
+    end
+
     it "renders paragraphs" do
       expect(described_class.render_for_email("abc")).to eq("<p>abc</p>")
     end

--- a/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
@@ -179,6 +179,14 @@ RSpec.describe GovukFormsMarkdown do
     it "renders horizontal rules as three dashes" do
       expect(described_class.render_plain_text("---")).to eq("---")
     end
+
+    it "renders the inline callout" do
+      expect(described_class.render_plain_text("^Callout text^")).to eq("Callout text")
+    end
+
+    it "renders the block callout" do
+      expect(described_class.render_plain_text("^^^\n\n## Heading\n\nparagraph content\n\n^^^")).to eq("Heading\n\nparagraph content")
+    end
   end
 
   describe ".render_for_email" do
@@ -236,6 +244,25 @@ RSpec.describe GovukFormsMarkdown do
       HTML
 
       expect_equal_ignoring_ws(described_class.render_for_email("---"), expected_html)
+    end
+
+    it "renders the inline callout" do
+      expected_html = <<~HTML
+        <div style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6; padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"><p style="margin: 0 0 20px 0">Callout text</p></div>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("^Callout text^"), expected_html)
+    end
+
+    it "renders the block callout" do
+      expected_html = <<~HTML
+        <div style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6; padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;">
+          <h2 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">Heading</h2>
+          <p>paragraph content</p>
+        </div>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("^^^\n\n## Heading\n\nparagraph content\n\n^^^"), expected_html)
     end
   end
 

--- a/spec/govuk_forms_markdown/plain_text_renderer/hrule_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/hrule_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#hrule" do
   subject(:renderer) { described_class.new }
 
-  it "does not render hrule and logs an error" do
-    expect(renderer.hrule).to be_nil
-    expect(renderer.errors).to eq([:used_hrule])
+  it "renders three dashes" do
+    expect(renderer.hrule).to eq "\n\n---"
+    expect(renderer.errors).to be_empty
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/d5t1W2Hs/3151-render-ses-emails-using-markdown

Adds new formatting features to the email and plaintext renderers. This should allow us to reimplement our existing emails as markdown, so we can render the same file with both the email renderer and the plaintext renderer instead of maintaining separate templates for plaintext and HTML emails. This should also reduce the amount of email HTML (and inline styles) we have to maintain by hand.

### Horizontal rule

This is a standard markdown feature so we're just adding a rendering method for it.

Markdown source:
```md
---
```

Rendered HTML:
```html
<hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">
```

Rendered plaintext:
```plain
---
```

### Inline callout

This is custom formatting not included in standard markdown, implemented to match [the 'Information callouts' feature in Govspeak](https://govspeak-preview.publishing.service.gov.uk/guide#information-callouts).

Markdown source:
```md
^Note this useful information^
```

Rendered HTML:
```html
<div style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6; padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;">
  <p style="margin: 0 0 20px 0">Note this useful information</p>
</div>
```

Rendered plaintext:
```plain
Note this useful information
```

### Block callout
This is custom formatting to allow inset text containing a block rather than just simple text. 

Markdown source:
```md
^^^
## Note this useful information

It's got a more complicated structure than the inline callout
^^^
```

Rendered HTML:
```html
<div style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6; padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;">
  <h2 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">Note this useful information</h2>
  <p>It's got a more complicated structure than the inline callout</p>
</div>
```

Rendered plaintext:
```plain
Note this useful information

It's got a more complicated structure than the inline callout
```

### Level 4 heading
This is custom formatting to allow inset text containing a block rather than just simple text. 

Markdown source:
```md
#### Note this important subheading
^^^
```

Rendered HTML:
```html
<h4 style="font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
  Note this important subheading
</h4>
```

Rendered plaintext:
```plain
Note this important subheading
```