### PR TITLE
Update type scale to preserve heading hierarchy

### DIFF
--- a/lib/govuk-forms-markdown/email_renderer.rb
+++ b/lib/govuk-forms-markdown/email_renderer.rb
@@ -26,13 +26,13 @@ module GovukFormsMarkdown
         HTML
       elsif header_level == 3
         <<~HTML
-          <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+          <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
             #{text}
           </h3>
         HTML
       elsif header_level == 4
         <<~HTML
-          <h4 style="font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+          <h4 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
             #{text}
           </h4>
         HTML

--- a/spec/govuk_forms_markdown/email_renderer/header_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/header_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe GovukFormsMarkdown::EmailRenderer, "#header" do
 
     it "formats heading level 3" do
       expected = <<~HTML.strip
-        <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+        <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
           Heading level 3
         </h3>
       HTML
@@ -40,7 +40,7 @@ RSpec.describe GovukFormsMarkdown::EmailRenderer, "#header" do
 
     it "formats heading level 4" do
       expected = <<~HTML.strip
-        <h4 style="font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+        <h4 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
           Heading level 4
         </h4>
       HTML

--- a/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe GovukFormsMarkdown do
 
     it "renders H3s with email inline styles" do
       expected_html = <<~HTML
-        <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+        <h3 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
           A heading
         </h3>
       HTML
@@ -212,7 +212,7 @@ RSpec.describe GovukFormsMarkdown do
 
     it "renders H4s with email inline styles" do
       expected_html = <<~HTML
-        <h4 style="font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
+        <h4 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">
           A heading
         </h4>
       HTML


### PR DESCRIPTION
When implementing the email changes in https://github.com/govuk-forms/forms-runner/pull/2124, there was some rationalisation of the heading sizes to make the hierarchy clear and consistent with Notify.

In #93 we introduced H4 elements and sized them to match this work, but didn't change the H3 sizes to match, resulting in H4s and H3s looking the same when rendered:

Before:
<img width="262" height="102" alt="image" src="https://github.com/user-attachments/assets/51d9b888-9755-46af-8d48-60acc8c39472" />

After:
<img width="305" height="93" alt="Screenshot 2026-06-26 at 11 23 57" src="https://github.com/user-attachments/assets/d5a2a653-c8ef-41f5-bdfc-ea26d7c95227" />
