### PR TITLE
Fix plaintext linebreaks

### DIFF
--- a/lib/govuk-forms-markdown/email_renderer.rb
+++ b/lib/govuk-forms-markdown/email_renderer.rb
@@ -131,6 +131,12 @@ module GovukFormsMarkdown
       HTML
     end
 
+    def linebreak
+      <<~HTML
+        <br/>
+      HTML
+    end
+
     def inline_callout(text)
       <<~HTML
         <div style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6; padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;">

--- a/lib/govuk-forms-markdown/plain_text_renderer.rb
+++ b/lib/govuk-forms-markdown/plain_text_renderer.rb
@@ -74,6 +74,10 @@ module GovukFormsMarkdown
       "#{linebreak}#{MAGIC_SEQUENCE} #{text.strip}"
     end
 
+    def linebreak
+      "\n"
+    end
+
     def inline_callout(text)
       paragraph(text)
     end
@@ -92,10 +96,6 @@ module GovukFormsMarkdown
     def add_to_error(error)
       symbolized_error = error.to_sym
       errors << symbolized_error unless errors.include?(symbolized_error)
-    end
-
-    def linebreak
-      "\n"
     end
 
     def render_block_callouts(text)

--- a/spec/govuk_forms_markdown/email_renderer/linebreak_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/linebreak_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::EmailRenderer, "#linebreak" do
+  subject(:renderer) { described_class.new }
+
+  it "renders a linebreak as a HTML linebreak" do
+    expected = <<~HTML.strip
+      <br/>
+    HTML
+    expect(renderer.linebreak.strip).to eq expected
+  end
+end

--- a/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
@@ -180,6 +180,10 @@ RSpec.describe GovukFormsMarkdown do
       expect(described_class.render_plain_text("---")).to eq("---")
     end
 
+    it "renders linebreaks as newline characters" do
+      expect(described_class.render_plain_text("First line  \nSecond line")).to eq("First line\nSecond line")
+    end
+
     it "renders the inline callout" do
       expect(described_class.render_plain_text("^Callout text^")).to eq("Callout text")
     end
@@ -254,6 +258,14 @@ RSpec.describe GovukFormsMarkdown do
       HTML
 
       expect_equal_ignoring_ws(described_class.render_for_email("---"), expected_html)
+    end
+
+    it "renders linebreaks as HTML linebreaks" do
+      expected_html = <<~HTML
+        <p>First line<br/>Second line</p>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("First line  \nSecond line"), expected_html)
     end
 
     it "renders the inline callout" do

--- a/spec/govuk_forms_markdown/plain_text_renderer/linebreak_spec.rb
+++ b/spec/govuk_forms_markdown/plain_text_renderer/linebreak_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukFormsMarkdown::PlainTextRenderer, "#linebreak" do
+  subject(:renderer) { described_class.new }
+
+  it "renders a linebreak as a plain text newline" do
+    expect(renderer.linebreak).to eq "\n"
+  end
+end


### PR DESCRIPTION
We weren't configuring a `linebreak` formatting method in the email or plaintext renderers, which meant we were relying on the default RedCarpet formatting for linebreaks. This caused an issue in the plain text renderer, since the default formatting renders HTML linebreak, resulting in `<br>` appearing in the plain text.

This commit explicitly configures the linebreak formatting for email and plaintext rendering.

We'd previously created a private `linebreak` method for rendering linebreaks in other plaintext formatting methods, which we reuse as a public formatting method here.