### PR TITLE
Allow H5s in email renderers

### DIFF
--- a/lib/govuk-forms-markdown/email_renderer.rb
+++ b/lib/govuk-forms-markdown/email_renderer.rb
@@ -36,6 +36,12 @@ module GovukFormsMarkdown
             #{text}
           </h4>
         HTML
+      elsif header_level == 5
+        <<~HTML
+          <h5 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 16px; line-height: 20px; font-weight: bold; color: #0B0C0C;">
+            #{text}
+          </h5>
+        HTML
       else
         add_to_error(:heading_levels)
         paragraph(text)

--- a/spec/govuk_forms_markdown/email_renderer/header_spec.rb
+++ b/spec/govuk_forms_markdown/email_renderer/header_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe GovukFormsMarkdown::EmailRenderer, "#header" do
 
   let(:allow_headings) { true }
 
-  non_supported_heading_levels = [1, 5, 6]
-  supported_heading_levels = [2, 3, 4]
+  non_supported_heading_levels = [1, 6]
+  supported_heading_levels = [2, 3, 4, 5]
   all_heading_levels = non_supported_heading_levels + supported_heading_levels
 
   context "when using non-supported heading levels" do
@@ -46,6 +46,16 @@ RSpec.describe GovukFormsMarkdown::EmailRenderer, "#header" do
       HTML
 
       expect(renderer.header("Heading level 4", 4).strip).to eq expected
+    end
+
+    it "formats heading level 5" do
+      expected = <<~HTML.strip
+        <h5 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 16px; line-height: 20px; font-weight: bold; color: #0B0C0C;">
+          Heading level 5
+        </h5>
+      HTML
+
+      expect(renderer.header("Heading level 5", 5).strip).to eq expected
     end
   end
 

--- a/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
+++ b/spec/govuk_forms_markdown/govuk_forms_markdown_spec.rb
@@ -220,6 +220,16 @@ RSpec.describe GovukFormsMarkdown do
       expect_equal_ignoring_ws(described_class.render_for_email("#### A heading"), expected_html)
     end
 
+    it "renders H5s with email inline styles" do
+      expected_html = <<~HTML
+        <h5 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 16px; line-height: 20px; font-weight: bold; color: #0B0C0C;">
+          A heading
+        </h5>
+      HTML
+
+      expect_equal_ignoring_ws(described_class.render_for_email("##### A heading"), expected_html)
+    end
+
     it "renders paragraphs" do
       expect(described_class.render_for_email("abc")).to eq("<p>abc</p>")
     end


### PR DESCRIPTION
We previously allowed H4s, but we will also need H5 elements in some emails. This PR allows us to use H5s and have them render in HTML and plaintext emails.

Markdown source:
```md
##### Note this important subheading
```

Rendered HTML:
```html
<h5 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 16px; line-height: 20px; font-weight: bold; color: #0B0C0C;">
  Note this important subheading
</h5>
```

Rendered plaintext:
```plain
Note this important subheading
```