### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Released
 
+### [0.12.0] - 2026-07-01
+
+- Allow H5 elements in email renderers [#100](https://github.com/alphagov/govuk-forms-markdown/pull/100)
+- Fix issue with plaintext linebreak formatting [#101](https://github.com/alphagov/govuk-forms-markdown/pull/101)
+
 ### [0.11.0] - 2026-06-29
 
 - Update type scale to preserve heading hierarchy [#98](https://github.com/alphagov/govuk-forms-markdown/pull/98)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-forms-markdown (0.11.0)
+    govuk-forms-markdown (0.12.0)
       redcarpet (~> 3.6)
 
 GEM
@@ -127,7 +127,7 @@ CHECKSUMS
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  govuk-forms-markdown (0.11.0)
+  govuk-forms-markdown (0.12.0)
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc

--- a/lib/govuk-forms-markdown/version.rb
+++ b/lib/govuk-forms-markdown/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GovukFormsMarkdown
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
Bumps the gem version to 0.12.0 so we can prepare a release.